### PR TITLE
Add favorites media upload and fix header navigation links

### DIFF
--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -27,6 +27,7 @@ body {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   position: relative;
   overflow: hidden;
+  z-index: 1;
 }
 
 .header::before {
@@ -39,6 +40,13 @@ body {
   background: radial-gradient(circle, rgba(255, 255, 255, 0.1) 1px, transparent 1px);
   background-size: 20px 20px;
   animation: float 6s ease-in-out infinite;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.header nav {
+  position: relative;
+  z-index: 1;
 }
 
 @keyframes gradientShift {

--- a/apps/frontend/src/pages/Bbs.tsx
+++ b/apps/frontend/src/pages/Bbs.tsx
@@ -26,7 +26,12 @@ const Bbs: React.FC = () => {
     setError('')
     api.listThreads()
       .then(list => { if (!cancelled) setThreads(list) })
-      .catch(e => { if (!cancelled) setError(e.message || '読み込みに失敗しました') })
+      .catch(e => {
+        if (!cancelled) {
+          const message = e instanceof Error ? e.message : '読み込みに失敗しました'
+          setError(message)
+        }
+      })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
   }, [])
@@ -38,7 +43,12 @@ const Bbs: React.FC = () => {
     setDetailError('')
     api.getThread(selectedId)
       .then(d => { if (!cancelled) setDetail(d) })
-      .catch(e => { if (!cancelled) setDetailError(e.message || '取得に失敗しました') })
+      .catch(e => {
+        if (!cancelled) {
+          const message = e instanceof Error ? e.message : '取得に失敗しました'
+          setDetailError(message)
+        }
+      })
       .finally(() => { if (!cancelled) setDetailLoading(false) })
     return () => { cancelled = true }
   }, [selectedId])
@@ -54,11 +64,12 @@ const Bbs: React.FC = () => {
       const list = await api.listThreads()
       setThreads(list)
       setSelectedId(r.id)
-    } catch (e:any) {
-      alert(e?.message || '作成に失敗しました')
-    } finally {
-      setCreating(false)
-    }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : '作成に失敗しました'
+        alert(message)
+      } finally {
+        setCreating(false)
+      }
   }
 
   const onReply = async (e: React.FormEvent) => {
@@ -70,11 +81,12 @@ const Bbs: React.FC = () => {
       setReplyBody('')
       const d = await api.getThread(selectedId)
       setDetail(d)
-    } catch (e:any) {
-      alert(e?.message || '返信に失敗しました')
-    } finally {
-      setReplying(false)
-    }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : '返信に失敗しました'
+        alert(message)
+      } finally {
+        setReplying(false)
+      }
   }
 
   const selectedTitle = useMemo(() => {

--- a/apps/frontend/src/pages/Favorites.tsx
+++ b/apps/frontend/src/pages/Favorites.tsx
@@ -1,4 +1,9 @@
-import React from 'react'
+import React, { useState } from 'react'
+
+type UploadItem = {
+  file: File
+  url: string
+}
 
 const Favorites: React.FC = () => {
   const items = [
@@ -6,14 +11,51 @@ const Favorites: React.FC = () => {
     { title: 'お気に入りの曲', desc: '楽しい気分になるプレイリスト' },
     { title: '参考リンク', desc: '面白いサイトのブックマーク' },
   ]
+
+  const [uploads, setUploads] = useState<UploadItem[]>([])
+
+  const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return
+    const newItems = Array.from(e.target.files).map((file) => ({
+      file,
+      url: URL.createObjectURL(file),
+    }))
+    setUploads((prev) => [...prev, ...newItems])
+  }
+
+  const renderPreview = (item: UploadItem) => {
+    const { file, url } = item
+    if (file.type.startsWith('image/')) {
+      return <img src={url} alt={file.name} style={{ maxWidth: '100%' }} />
+    }
+    if (file.type.startsWith('audio/')) {
+      return <audio controls src={url} />
+    }
+    if (file.type.startsWith('video/')) {
+      return <video controls src={url} style={{ maxWidth: '100%' }} />
+    }
+    return (
+      <a href={url} download={file.name} style={{ color: 'white', textDecoration: 'underline' }}>
+        {file.name}
+      </a>
+    )
+  }
+
   return (
     <div style={{ maxWidth: 900, margin: '0 auto' }}>
       <h2 style={{ color: 'white', textShadow: '1px 1px 2px #333' }}>好きなもの置き場</h2>
+      <input type="file" multiple onChange={handleUpload} style={{ marginTop: 12 }} />
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 16, marginTop: 12 }}>
         {items.map((it, i) => (
           <div key={i} style={{ background: 'rgba(0,0,0,0.3)', color: 'white', padding: 16, borderRadius: 12, border: '2px solid rgba(255,255,255,0.2)' }}>
             <h3 style={{ marginBottom: 8 }}>{it.title}</h3>
             <p>{it.desc}</p>
+          </div>
+        ))}
+        {uploads.map((item, i) => (
+          <div key={`u-${i}`} style={{ background: 'rgba(0,0,0,0.3)', color: 'white', padding: 16, borderRadius: 12, border: '2px solid rgba(255,255,255,0.2)' }}>
+            <h3 style={{ marginBottom: 8 }}>{item.file.name}</h3>
+            {renderPreview(item)}
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- allow uploading any media type on favorites page with previews for common formats
- ensure header background overlay sits behind navigation content
- replace any-typed catches in BBS page with safe error handling
- guard API calls on BBS page with Error checks to avoid undefined messages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c805f9cffc832c9c7c5ea5dd61b602