### PR TITLE
Add server-backed favorites uploads and simplify BBS threads

### DIFF
--- a/apps/frontend/src/App.css
+++ b/apps/frontend/src/App.css
@@ -27,6 +27,7 @@ body {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   position: relative;
   overflow: hidden;
+  z-index: 1;
 }
 
 .header::before {
@@ -39,6 +40,14 @@ body {
   background: radial-gradient(circle, rgba(255, 255, 255, 0.1) 1px, transparent 1px);
   background-size: 20px 20px;
   animation: float 6s ease-in-out infinite;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.header nav {
+  position: relative;
+  z-index: 1;
+  pointer-events: auto;
 }
 
 @keyframes gradientShift {

--- a/apps/frontend/src/lib/api.ts
+++ b/apps/frontend/src/lib/api.ts
@@ -3,7 +3,7 @@ const DEFAULT_BASE = import.meta.env.VITE_API_BASE_URL || '';
 export interface ThreadMeta {
   pk: string; // THREAD#<id>
   sk: 'META';
-  title: string;
+  name: string;
   body: string;
   createdAt: string;
   updatedAt: string;
@@ -22,6 +22,16 @@ export interface ThreadDetailResponse {
   replies: ThreadReply[];
 }
 
+export interface FavoriteItem {
+  id: string;
+  name: string;
+  kind: 'file' | 'text';
+  dataUrl?: string;
+  mime?: string;
+  text?: string;
+  createdAt: string;
+}
+
 async function http<T>(path: string, init?: RequestInit): Promise<T> {
   const url = `${DEFAULT_BASE}${path}`;
   const res = await fetch(url, {
@@ -29,10 +39,22 @@ async function http<T>(path: string, init?: RequestInit): Promise<T> {
     ...init,
   });
   if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`HTTP ${res.status}: ${text || res.statusText}`);
+    const ct = res.headers.get('content-type') || ''
+    let message = res.statusText
+    if (ct.includes('application/json')) {
+      try {
+        const data = (await res.json()) as { error?: string }
+        message = data?.error || message
+      } catch {
+        // ignore parse errors
+      }
+    } else {
+      const text = await res.text().catch(() => '')
+      if (text && text.length < 200 && !text.trim().startsWith('<')) message = text
+    }
+    throw new Error(`HTTP ${res.status}: ${message}`)
   }
-  return (await res.json()) as T;
+  return (await res.json()) as T
 }
 
 export const api = {
@@ -42,7 +64,7 @@ export const api = {
   getThread(id: string): Promise<ThreadDetailResponse> {
     return http<ThreadDetailResponse>(`/api/threads?id=${encodeURIComponent(id)}`);
   },
-  createThread(input: { title: string; body: string }): Promise<{ id: string }> {
+  createThread(input: { name?: string; body: string }): Promise<{ id: string }> {
     return http<{ id: string }>(`/api/threads`, {
       method: 'POST',
       body: JSON.stringify(input),
@@ -52,6 +74,25 @@ export const api = {
     return http<{ ok: boolean }>(`/api/threads?id=${encodeURIComponent(id)}`, {
       method: 'POST',
       body: JSON.stringify(input),
+    });
+  },
+  deleteThread(id: string): Promise<{ ok: boolean }> {
+    return http<{ ok: boolean }>(`/api/threads?id=${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    });
+  },
+  listFavorites(): Promise<FavoriteItem[]> {
+    return http<FavoriteItem[]>('/api/favorites');
+  },
+  addFavorite(input: { name: string; dataUrl?: string; mime?: string; text?: string }): Promise<{ id: string }> {
+    return http<{ id: string }>('/api/favorites', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  },
+  deleteFavorite(id: string): Promise<{ ok: boolean }> {
+    return http<{ ok: boolean }>(`/api/favorites?id=${encodeURIComponent(id)}`, {
+      method: 'DELETE',
     });
   },
 };

--- a/apps/frontend/src/pages/Bbs.tsx
+++ b/apps/frontend/src/pages/Bbs.tsx
@@ -1,18 +1,20 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { api, extractIdFromPk } from '../lib/api'
 import type { ThreadMeta, ThreadReply } from '../lib/api'
+
+const SELECTED_KEY = 'bbsSelected'
 
 const Bbs: React.FC = () => {
   const [threads, setThreads] = useState<ThreadMeta[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string>('')
 
-  const [selectedId, setSelectedId] = useState<string>('')
+  const [selectedId, setSelectedId] = useState<string>(() => window.localStorage.getItem(SELECTED_KEY) || '')
   const [detail, setDetail] = useState<{ thread: ThreadMeta; replies: ThreadReply[] } | null>(null)
   const [detailLoading, setDetailLoading] = useState(false)
   const [detailError, setDetailError] = useState('')
 
-  const [newTitle, setNewTitle] = useState('')
+  const [newName, setNewName] = useState('')
   const [newBody, setNewBody] = useState('')
   const [creating, setCreating] = useState(false)
 
@@ -21,12 +23,21 @@ const Bbs: React.FC = () => {
   const [replying, setReplying] = useState(false)
 
   useEffect(() => {
+    window.localStorage.setItem(SELECTED_KEY, selectedId)
+  }, [selectedId])
+
+  useEffect(() => {
     let cancelled = false
     setLoading(true)
     setError('')
     api.listThreads()
       .then(list => { if (!cancelled) setThreads(list) })
-      .catch(e => { if (!cancelled) setError(e.message || '読み込みに失敗しました') })
+      .catch(e => {
+        if (!cancelled) {
+          const message = e instanceof Error ? e.message : '読み込みに失敗しました'
+          setError(message)
+        }
+      })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
   }, [])
@@ -38,24 +49,34 @@ const Bbs: React.FC = () => {
     setDetailError('')
     api.getThread(selectedId)
       .then(d => { if (!cancelled) setDetail(d) })
-      .catch(e => { if (!cancelled) setDetailError(e.message || '取得に失敗しました') })
+      .catch(e => {
+        if (!cancelled) {
+          const message = e instanceof Error
+            ? e.message.startsWith('HTTP 404')
+              ? 'スレッドが見つかりません'
+              : e.message
+            : '取得に失敗しました'
+          setDetailError(message)
+        }
+      })
       .finally(() => { if (!cancelled) setDetailLoading(false) })
     return () => { cancelled = true }
   }, [selectedId])
 
   const onCreate = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!newTitle.trim() || !newBody.trim()) return
+    if (!newBody.trim()) return
     setCreating(true)
     try {
-      const r = await api.createThread({ title: newTitle.trim(), body: newBody.trim() })
-      setNewTitle('')
+      const r = await api.createThread({ name: newName.trim() || '匿名', body: newBody.trim() })
+      setNewName('')
       setNewBody('')
       const list = await api.listThreads()
       setThreads(list)
       setSelectedId(r.id)
-    } catch (e:any) {
-      alert(e?.message || '作成に失敗しました')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : '作成に失敗しました'
+      alert(message)
     } finally {
       setCreating(false)
     }
@@ -70,18 +91,28 @@ const Bbs: React.FC = () => {
       setReplyBody('')
       const d = await api.getThread(selectedId)
       setDetail(d)
-    } catch (e:any) {
-      alert(e?.message || '返信に失敗しました')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : '返信に失敗しました'
+      alert(message)
     } finally {
       setReplying(false)
     }
   }
 
-  const selectedTitle = useMemo(() => {
-    if (!selectedId) return ''
-    const meta = threads.find(t => extractIdFromPk(t.pk) === selectedId)
-    return meta?.title || ''
-  }, [selectedId, threads])
+  const handleDeleteThread = async (id: string) => {
+    if (!window.confirm('本当に削除しますか？')) return
+    try {
+      await api.deleteThread(id)
+      setThreads(prev => prev.filter(t => extractIdFromPk(t.pk) !== id))
+      if (selectedId === id) {
+        setSelectedId('')
+        setDetail(null)
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : '削除に失敗しました'
+      alert(message)
+    }
+  }
 
   return (
     <div style={{ maxWidth: 980, margin: '0 auto', display: 'grid', gap: 16, gridTemplateColumns: '1fr 2fr' }}>
@@ -90,7 +121,7 @@ const Bbs: React.FC = () => {
         <div style={{ background: 'rgba(0,0,0,0.3)', padding: 12, borderRadius: 12, border: '2px solid rgba(255,255,255,0.2)', color: 'white' }}>
           <h3 style={{ marginBottom: 8 }}>新規スレッド作成</h3>
           <form onSubmit={onCreate} style={{ display: 'grid', gap: 8 }}>
-            <input value={newTitle} onChange={e=>setNewTitle(e.target.value)} placeholder="タイトル" style={{ padding: 8, borderRadius: 8, border: '1px solid #ccc' }} />
+            <input value={newName} onChange={e=>setNewName(e.target.value)} placeholder="名前（省略可）" style={{ padding: 8, borderRadius: 8, border: '1px solid #ccc' }} />
             <textarea value={newBody} onChange={e=>setNewBody(e.target.value)} placeholder="本文" rows={4} style={{ padding: 8, borderRadius: 8, border: '1px solid #ccc' }} />
             <button type="submit" disabled={creating} style={{ padding: '8px 12px', borderRadius: 8, border: 'none', background: '#4ECDC4', color: '#fff', cursor: 'pointer' }}>{creating ? '作成中...' : '作成'}</button>
           </form>
@@ -104,10 +135,13 @@ const Bbs: React.FC = () => {
             const id = extractIdFromPk(t.pk)
             const isSel = id === selectedId
             return (
-              <button key={t.pk + t.sk} onClick={()=>setSelectedId(id)} style={{ textAlign: 'left', padding: 12, borderRadius: 10, border: isSel ? '2px solid #FFD700' : '2px solid rgba(255,255,255,0.2)', background: isSel ? 'rgba(255,215,0,0.15)' : 'rgba(0,0,0,0.3)', color: 'white', cursor: 'pointer' }}>
-                <div style={{ fontWeight: 'bold' }}>{t.title}</div>
-                <div style={{ fontSize: 12, opacity: 0.8 }}>更新: {new Date(t.updatedAt).toLocaleString()}</div>
-              </button>
+              <div key={t.pk + t.sk} style={{ display: 'flex', gap: 8 }}>
+                <button onClick={()=>setSelectedId(id)} style={{ flex: 1, textAlign: 'left', padding: 12, borderRadius: 10, border: isSel ? '2px solid #FFD700' : '2px solid rgba(255,255,255,0.2)', background: isSel ? 'rgba(255,215,0,0.15)' : 'rgba(0,0,0,0.3)', color: 'white', cursor: 'pointer' }}>
+                  <div style={{ fontWeight: 'bold' }}>{t.body.slice(0, 30)}</div>
+                  <div style={{ fontSize: 12, opacity: 0.8 }}>更新: {new Date(t.updatedAt).toLocaleString()}</div>
+                </button>
+                <button onClick={() => handleDeleteThread(id)} style={{ padding: '0 8px', borderRadius: 8, border: 'none', background: '#E63946', color: '#fff', cursor: 'pointer' }}>削除</button>
+              </div>
             )
           })}
           {!loading && !threads.length && <p style={{ color: 'white' }}>スレッドがありません。最初のスレッドを作成しましょう！</p>}
@@ -115,16 +149,15 @@ const Bbs: React.FC = () => {
       </div>
 
       <div>
-        <h3 style={{ color: 'white', marginBottom: 8 }}>{selectedTitle ? `選択中: ${selectedTitle}` : 'スレッド詳細'}</h3>
+        <h3 style={{ color: 'white', marginBottom: 8 }}>スレッド詳細</h3>
         {!selectedId && <p style={{ color: 'white' }}>左からスレッドを選択するか、新規作成してください。</p>}
         {selectedId && detailLoading && <p style={{ color: 'white' }}>読み込み中...</p>}
         {selectedId && detailError && <p style={{ color: 'pink' }}>{detailError}</p>}
         {selectedId && detail && (
           <div style={{ display: 'grid', gap: 12 }}>
             <div style={{ background: 'rgba(0,0,0,0.35)', padding: 12, borderRadius: 10, border: '2px solid rgba(255,255,255,0.2)', color: 'white' }}>
-              <div style={{ fontWeight: 'bold', fontSize: 18 }}>{detail.thread.title}</div>
+              <div style={{ fontWeight: 'bold' }}>{detail.thread.name} <span style={{ fontSize: 12, opacity: 0.7 }}>({new Date(detail.thread.createdAt).toLocaleString()})</span></div>
               <div style={{ whiteSpace: 'pre-wrap', marginTop: 6 }}>{detail.thread.body}</div>
-              <div style={{ fontSize: 12, opacity: 0.8, marginTop: 6 }}>作成: {new Date(detail.thread.createdAt).toLocaleString()}</div>
             </div>
             <div style={{ display: 'grid', gap: 8 }}>
               {detail.replies.map((r: ThreadReply) => (

--- a/apps/frontend/src/pages/Favorites.tsx
+++ b/apps/frontend/src/pages/Favorites.tsx
@@ -1,19 +1,141 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
+import { api, type FavoriteItem } from '../lib/api'
+
+const LS_KEY = 'favoriteUploads'
 
 const Favorites: React.FC = () => {
-  const items = [
-    { title: 'モモンガの写真', desc: 'ふわふわ滑空！' },
-    { title: 'お気に入りの曲', desc: '楽しい気分になるプレイリスト' },
-    { title: '参考リンク', desc: '面白いサイトのブックマーク' },
-  ]
+  const [uploads, setUploads] = useState<FavoriteItem[]>([])
+  const [textName, setTextName] = useState('')
+  const [textBody, setTextBody] = useState('')
+
+  useEffect(() => {
+    api
+      .listFavorites()
+      .then(list => {
+        setUploads(list)
+        window.localStorage.setItem(LS_KEY, JSON.stringify(list))
+      })
+      .catch(err => {
+        console.error(err)
+        const cached = window.localStorage.getItem(LS_KEY)
+        if (cached) {
+          try {
+            setUploads(JSON.parse(cached))
+          } catch {
+            /* ignore */
+          }
+        }
+      })
+  }, [])
+
+  const handleUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return
+    const files = Array.from(e.target.files)
+    files.forEach((file) => {
+      const name = window.prompt('名前を入力してください', file.name) || file.name
+      const reader = new FileReader()
+      reader.onload = async () => {
+        const dataUrl = reader.result as string
+        try {
+          const res = await api.addFavorite({ name, dataUrl, mime: file.type })
+          const item: FavoriteItem = {
+            id: res.id,
+            name,
+            kind: 'file',
+            dataUrl,
+            mime: file.type,
+            createdAt: new Date().toISOString(),
+          }
+          setUploads(prev => {
+            const next = [...prev, item]
+            window.localStorage.setItem(LS_KEY, JSON.stringify(next))
+            return next
+          })
+        } catch (err) {
+          console.error(err)
+        }
+      }
+      reader.readAsDataURL(file)
+    })
+    e.target.value = ''
+  }
+
+  const handleTextSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!textBody.trim()) return
+    const name = textName || '無題'
+    try {
+      const res = await api.addFavorite({ name, text: textBody })
+      const item: FavoriteItem = {
+        id: res.id,
+        name,
+        kind: 'text',
+        text: textBody,
+        createdAt: new Date().toISOString(),
+      }
+      setUploads(prev => {
+        const next = [...prev, item]
+        window.localStorage.setItem(LS_KEY, JSON.stringify(next))
+        return next
+      })
+      setTextName('')
+      setTextBody('')
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    try {
+      await api.deleteFavorite(id)
+      setUploads(prev => {
+        const next = prev.filter(item => item.id !== id)
+        window.localStorage.setItem(LS_KEY, JSON.stringify(next))
+        return next
+      })
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const renderPreview = (item: FavoriteItem) => {
+    if (item.kind === 'text' && item.text) {
+      return <p style={{ whiteSpace: 'pre-wrap' }}>{item.text}</p>
+    }
+    const { dataUrl, mime, name } = item
+    if (mime?.startsWith('image/')) {
+      return <img src={dataUrl} alt={name} style={{ maxWidth: '100%' }} />
+    }
+    if (mime?.startsWith('audio/')) {
+      return <audio controls src={dataUrl} />
+    }
+    if (mime?.startsWith('video/')) {
+      return <video controls src={dataUrl} style={{ maxWidth: '100%' }} />
+    }
+    return (
+      <a href={dataUrl} download={name} style={{ color: 'white', textDecoration: 'underline' }}>
+        {name}
+      </a>
+    )
+  }
+
   return (
     <div style={{ maxWidth: 900, margin: '0 auto' }}>
       <h2 style={{ color: 'white', textShadow: '1px 1px 2px #333' }}>好きなもの置き場</h2>
+      <input type="file" multiple onChange={handleUpload} style={{ marginTop: 12 }} />
+      <form onSubmit={handleTextSubmit} style={{ marginTop: 12, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <input value={textName} onChange={(e) => setTextName(e.target.value)} placeholder="名前" />
+        <textarea value={textBody} onChange={(e) => setTextBody(e.target.value)} placeholder="テキストを入力" />
+        <button type="submit">テキスト追加</button>
+      </form>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))', gap: 16, marginTop: 12 }}>
-        {items.map((it, i) => (
-          <div key={i} style={{ background: 'rgba(0,0,0,0.3)', color: 'white', padding: 16, borderRadius: 12, border: '2px solid rgba(255,255,255,0.2)' }}>
-            <h3 style={{ marginBottom: 8 }}>{it.title}</h3>
-            <p>{it.desc}</p>
+        {uploads.map((item) => (
+          <div key={item.id} style={{ background: 'rgba(0,0,0,0.3)', color: 'white', padding: 16, borderRadius: 12, border: '2px solid rgba(255,255,255,0.2)' }}>
+            <h3 style={{ marginBottom: 8 }}>{item.name}</h3>
+            {renderPreview(item)}
+            <button onClick={() => handleDelete(item.id)} style={{ marginTop: 8 }}>
+              削除
+            </button>
           </div>
         ))}
       </div>

--- a/functions/favorites/handler.ts
+++ b/functions/favorites/handler.ts
@@ -1,0 +1,121 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand, QueryCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
+import { randomBytes } from "node:crypto";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+ type AnyEvent = any;
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const TABLE = process.env.TABLE_FAVORITES || process.env.TABLE_THREADS;
+
+const json = (code: number, body: unknown) => ({
+  statusCode: code,
+  headers: {
+    "content-type": "application/json",
+    "access-control-allow-origin": "*",
+    "access-control-allow-methods": "GET,POST,DELETE,OPTIONS",
+    "access-control-allow-headers": "Content-Type",
+  },
+  body: JSON.stringify(body),
+});
+
+const mOf = (e: AnyEvent) => e?.httpMethod || e?.requestContext?.http?.method || e?.requestContext?.httpMethod || "";
+const pOf = (e: AnyEvent) => (e?.path || e?.rawPath || e?.resourcePath || "") as string;
+
+function getQueryParam(e: AnyEvent, key: string): string {
+  if (e?.rawQueryString) {
+    const sp = new URLSearchParams(e.rawQueryString);
+    const v = sp.get(key);
+    if (v != null) return v;
+  }
+  if (e?.multiValueQueryStringParameters?.[key]?.length) {
+    return e.multiValueQueryStringParameters[key][0];
+  }
+  if (e?.queryStringParameters?.[key] != null) {
+    return e.queryStringParameters[key];
+  }
+  return "";
+}
+
+export const handler = async (event: AnyEvent) => {
+  try {
+    if (!TABLE) return json(500, { error: "misconfigured: TABLE_FAVORITES is not set" });
+
+    const method = mOf(event);
+    const path = pOf(event);
+    if (method === "OPTIONS") return { statusCode: 204, headers: json(200, {}).headers, body: "" };
+
+    const isFavRoute = path.includes("/api/favorites");
+
+    if (isFavRoute && method === "GET") {
+      const r = await ddb.send(
+        new QueryCommand({
+          TableName: TABLE,
+          KeyConditionExpression: "pk = :pk",
+          ExpressionAttributeValues: { ":pk": "FAVORITES" },
+          ScanIndexForward: false,
+          Limit: 100,
+        })
+      );
+      const items = (r.Items ?? []).map(({ pk, sk, ...rest }) => rest);
+      return json(200, items);
+    }
+
+    if (isFavRoute && method === "POST") {
+      const body = JSON.parse(event.body || "{}");
+      const name = (body.name || "無題").toString().slice(0, 100);
+      const now = new Date().toISOString();
+      const id = randomBytes(6).toString("base64url");
+      const item: any = { pk: "FAVORITES", sk: id, id, name, createdAt: now };
+
+      if (typeof body.text === "string") {
+        const text = body.text.toString().slice(0, 2000);
+        if (!text) return json(400, { error: "empty" });
+        item.kind = "text";
+        item.text = text;
+      } else if (typeof body.dataUrl === "string") {
+        const dataUrl = body.dataUrl.toString();
+        const mime = (body.mime || "").toString().slice(0, 100);
+        item.kind = "file";
+        item.dataUrl = dataUrl;
+        item.mime = mime;
+      } else {
+        return json(400, { error: "invalid" });
+      }
+
+      await ddb.send(new PutCommand({ TableName: TABLE, Item: item }));
+      return json(201, { id });
+    }
+
+    if (isFavRoute && method === "DELETE") {
+      const id = getQueryParam(event, "id");
+      if (!id) return json(400, { error: "invalid" });
+      try {
+        await ddb.send(
+          new DeleteCommand({
+            TableName: TABLE,
+            Key: { pk: "FAVORITES", sk: id },
+            ConditionExpression: "attribute_exists(pk)",
+          })
+        );
+        return json(200, { ok: true });
+      } catch (err: any) {
+        if (err?.name === "ConditionalCheckFailedException") {
+          return json(404, { error: "not found" });
+        }
+        throw err;
+      }
+    }
+
+    return json(404, { error: "not found" });
+  } catch (e) {
+    console.error("ERROR", {
+      message: (e as any)?.message,
+      stack: (e as any)?.stack,
+      path: pOf(event),
+      method: mOf(event),
+    });
+    return json(500, { error: "internal" });
+  }
+};
+

--- a/functions/favorites/package.json
+++ b/functions/favorites/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "favorites-fn",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.883.0",
+    "@aws-sdk/lib-dynamodb": "^3.883.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.4.0",
+    "esbuild": "^0.25.9",
+    "typescript": "^5.5.0"
+  }
+}

--- a/functions/favorites/tsconfig.json
+++ b/functions/favorites/tsconfig.json
@@ -1,0 +1,10 @@
+﻿{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/functions/threads/handler.ts
+++ b/functions/threads/handler.ts
@@ -1,5 +1,5 @@
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient, PutCommand, QueryCommand, UpdateCommand } from "@aws-sdk/lib-dynamodb";
+import { DynamoDBDocumentClient, PutCommand, QueryCommand, UpdateCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
 import { randomBytes } from "node:crypto";
 
 type AnyEvent = any;
@@ -12,7 +12,7 @@ const json = (code: number, body: unknown) => ({
   headers: {
     "content-type": "application/json",
     "access-control-allow-origin": "*",
-    "access-control-allow-methods": "GET,POST,OPTIONS",
+    "access-control-allow-methods": "GET,POST,DELETE,OPTIONS",
     "access-control-allow-headers": "Content-Type"
   },
   body: JSON.stringify(body),
@@ -122,18 +122,36 @@ export const handler = async (event: AnyEvent) => {
         return json(201, { ok:true });
       }
 
-      const title = (body.title || "").toString().trim().slice(0, 80);
+      const name = (body.name || "匿名").toString().slice(0,40);
       const text  = (body.body  || "").toString().trim().slice(0, 1000);
-      if (!title || !text) return json(400, { error: "invalid" });
+      if (!text) return json(400, { error: "empty" });
 
       const now = new Date().toISOString();
       const newId  = randomBytes(6).toString("base64url");
 
       await ddb.send(new PutCommand({
         TableName: TABLE,
-        Item: { pk:`THREAD#${newId}`, sk:"META", title, body:text, createdAt:now, updatedAt:now, GSI1PK:"THREADS", GSI1SK:now }
+        Item: { pk:`THREAD#${newId}`, sk:"META", name, body:text, createdAt:now, updatedAt:now, GSI1PK:"THREADS", GSI1SK:now }
       }));
       return json(201, { id: newId });
+    }
+
+    if (isThreadsRoute && method === "DELETE" && !isRepliesIdPath) {
+      const qid = normId(getQueryParam(event, "id"));
+      if (!qid) return json(400, { error: "invalid" });
+
+      const items = await ddb.send(new QueryCommand({
+        TableName: TABLE,
+        KeyConditionExpression: "pk = :pk",
+        ExpressionAttributeValues: { ":pk": `THREAD#${qid}` },
+        Limit: 200,
+      }));
+      if (!items.Items?.length) return json(404, { error: "not found" });
+
+      for (const it of items.Items) {
+        await ddb.send(new DeleteCommand({ TableName: TABLE, Key: { pk: it.pk, sk: it.sk } }));
+      }
+      return json(200, { ok: true });
     }
 
     // 旧PATH互換


### PR DESCRIPTION
## Summary
- allow uploading any media type on favorites page with server persistence and text entries
- persist favorites on server via DynamoDB API and enable deletion
- ensure header background overlay sits behind navigation content
- replace any-typed catches in BBS page with safe error handling
- guard API calls on BBS page with Error checks to avoid undefined messages
- trim HTML from API error responses and map HTTP 404 to readable messages
- simplify threads to store only author name and body and provide deletion endpoint
- remember selected thread and mirror favorites data in localStorage for persistence
- simplify BBS list error handling
- remove placeholder items from favorites and tidy reply handler

## Testing
- `npm --prefix apps/frontend run lint`
- `npm --prefix apps/frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68c805f9cffc832c9c7c5ea5dd61b602