### PR TITLE
Shorten and copy shareable links

### DIFF
--- a/apps/frontend/src/pages/BulletHell.tsx
+++ b/apps/frontend/src/pages/BulletHell.tsx
@@ -98,10 +98,9 @@ const BulletHell: React.FC = () => {
     }
   }, [lastTap, touchStart, running])
 
-  // Load high scores from localStorage
+  // Load high scores from localStorage (通算記録)
   useEffect(() => {
-    const today = new Date().toDateString()
-    const saved = localStorage.getItem(`bullet-hell-scores-${today}`)
+    const saved = localStorage.getItem('bullet-hell-all-time-scores')
     if (saved) {
       try {
         setHighScores(JSON.parse(saved))
@@ -111,11 +110,10 @@ const BulletHell: React.FC = () => {
     }
   }, [])
 
-  // Save high scores to localStorage
+  // Save high scores to localStorage (通算記録)
   useEffect(() => {
     if (highScores.length > 0) {
-      const today = new Date().toDateString()
-      localStorage.setItem(`bullet-hell-scores-${today}`, JSON.stringify(highScores))
+      localStorage.setItem('bullet-hell-all-time-scores', JSON.stringify(highScores))
     }
   }, [highScores])
 
@@ -167,9 +165,9 @@ const BulletHell: React.FC = () => {
           if (lives - 1 <= 0) {
             setRunning(false)
             setGameOver(true)
-            // ハイスコアに追加
+            // ハイスコアに追加（TOP3のみ保持）
             setHighScores(prev => {
-              const newScores = [...prev, score].sort((a, b) => b - a).slice(0, 10)
+              const newScores = [...prev, score].sort((a, b) => b - a).slice(0, 3)
               return newScores
             })
           }
@@ -255,17 +253,25 @@ const BulletHell: React.FC = () => {
           <div className="comic-text" style={{ color: '#c8e6c9', fontSize: '1.2rem', marginBottom: '16px' }}>最終スコア: {score}</div>
           {highScores.length > 0 && (
             <div>
-              <div className="comic-text" style={{ color: '#fff3e0', fontSize: '1.2rem', marginBottom: '12px' }}>🏆 今日のハイスコア 🏆</div>
-              <div style={{ display: 'flex', flexDirection: 'column', gap: '4px', alignItems: 'center' }}>
-                {highScores.slice(0, 5).map((score, index) => (
-                  <div key={index} className="comic-text" style={{ 
-                    color: index === 0 ? '#ffd700' : '#c8e6c9', 
-                    fontSize: '1rem',
-                    fontWeight: index === 0 ? 'bold' : 'normal'
-                  }}>
-                    {index + 1}位: {score}点
-                  </div>
-                ))}
+              <div className="comic-text" style={{ color: '#fff3e0', fontSize: '1.2rem', marginBottom: '12px' }}>🏆 通算ハイスコア TOP3 🏆</div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', alignItems: 'center' }}>
+                {highScores.map((score, index) => {
+                  const medals = ['🥇', '🥈', '🥉']
+                  const colors = ['#ffd700', '#c0c0c0', '#cd7f32']
+                  return (
+                    <div key={index} className="comic-text" style={{ 
+                      color: colors[index] || '#c8e6c9', 
+                      fontSize: index === 0 ? '1.1rem' : '1rem',
+                      fontWeight: index === 0 ? 'bold' : 'normal',
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px'
+                    }}>
+                      <span style={{ fontSize: '1.2rem' }}>{medals[index]}</span>
+                      <span>{index + 1}位: {score}点</span>
+                    </div>
+                  )
+                })}
               </div>
             </div>
           )}

--- a/apps/frontend/src/pages/DataExport.tsx
+++ b/apps/frontend/src/pages/DataExport.tsx
@@ -5,6 +5,7 @@ const DataExport: React.FC = () => {
   const { favorites, tweets } = useAppData()
   const [shareUrl, setShareUrl] = useState('')
   const [isGenerating, setIsGenerating] = useState(false)
+  const [copySuccess, setCopySuccess] = useState(false)
 
   // データをエクスポート用に準備
   const exportData = () => {
@@ -28,6 +29,30 @@ const DataExport: React.FC = () => {
     URL.revokeObjectURL(url)
   }
 
+  // データを圧縮してリンクを短縮
+  const compressData = (data: any): string => {
+    // 不要な情報を削除してデータサイズを削減
+    const compactData = {
+      f: data.favorites.map((fav: any) => ({
+        id: fav.id,
+        name: fav.name,
+        url: fav.url,
+        type: fav.type
+      })),
+      t: data.tweets.map((tweet: any) => ({
+        id: tweet.id,
+        text: tweet.text,
+        timestamp: tweet.timestamp
+      }))
+    }
+    
+    // JSONを最小化（スペース削除）
+    const jsonStr = JSON.stringify(compactData)
+    
+    // Base64エンコード
+    return btoa(unescape(encodeURIComponent(jsonStr)))
+  }
+
   // 共有リンクを生成
   const generateShareLink = async () => {
     setIsGenerating(true)
@@ -35,24 +60,24 @@ const DataExport: React.FC = () => {
     try {
       const data = {
         favorites,
-        tweets,
-        exportedAt: new Date().toISOString(),
-        version: '1.0'
+        tweets
       }
       
-      // Base64エンコードしてURLに埋め込み
-      const dataStr = JSON.stringify(data)
-      const encodedData = btoa(unescape(encodeURIComponent(dataStr)))
+      // データを圧縮
+      const encodedData = compressData(data)
       
       // 現在のサイトのURLにクエリパラメータとして追加
       const currentUrl = window.location.origin + window.location.pathname
-      const shareUrl = `${currentUrl}?import=${encodedData}`
+      const shareUrl = `${currentUrl}?d=${encodedData}`
       
       setShareUrl(shareUrl)
       
       // クリップボードにコピー
       await navigator.clipboard.writeText(shareUrl)
-      alert('共有リンクをクリップボードにコピーしました！')
+      
+      // 成功フィードバック
+      setCopySuccess(true)
+      setTimeout(() => setCopySuccess(false), 3000) // 3秒後に非表示
     } catch (error) {
       console.error('Failed to generate share link:', error)
       alert('共有リンクの生成に失敗しました')
@@ -90,16 +115,52 @@ const DataExport: React.FC = () => {
     event.target.value = ''
   }
 
+  // データを展開
+  const decompressData = (encodedData: string) => {
+    try {
+      const jsonStr = decodeURIComponent(escape(atob(encodedData)))
+      const compactData = JSON.parse(jsonStr)
+      
+      // 圧縮されたデータを元の形式に戻す
+      const data = {
+        favorites: compactData.f || [],
+        tweets: compactData.t || []
+      }
+      
+      return data
+    } catch (error) {
+      console.error('Failed to decompress data:', error)
+      return null
+    }
+  }
+
   // URLパラメータからデータを自動インポート
   React.useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search)
-    const importData = urlParams.get('import')
     
-    if (importData) {
+    // 新しい圧縮形式（?d=）をチェック
+    let importDataParam = urlParams.get('d')
+    let isCompressed = true
+    
+    // 旧形式（?import=）もサポート
+    if (!importDataParam) {
+      importDataParam = urlParams.get('import')
+      isCompressed = false
+    }
+    
+    if (importDataParam) {
       try {
-        const data = JSON.parse(decodeURIComponent(escape(atob(importData))))
+        let data
         
-        if (data.favorites && data.tweets) {
+        if (isCompressed) {
+          // 新しい圧縮形式
+          data = decompressData(importDataParam)
+        } else {
+          // 旧形式
+          data = JSON.parse(decodeURIComponent(escape(atob(importDataParam))))
+        }
+        
+        if (data && data.favorites && data.tweets) {
           localStorage.setItem('favoriteUploads', JSON.stringify(data.favorites))
           localStorage.setItem('tweets', JSON.stringify(data.tweets))
           

--- a/apps/frontend/src/pages/DataExport.tsx
+++ b/apps/frontend/src/pages/DataExport.tsx
@@ -7,27 +7,6 @@ const DataExport: React.FC = () => {
   const [isGenerating, setIsGenerating] = useState(false)
   const [copySuccess, setCopySuccess] = useState(false)
 
-  // データをエクスポート用に準備
-  const exportData = () => {
-    const data = {
-      favorites,
-      tweets,
-      exportedAt: new Date().toISOString(),
-      version: '1.0'
-    }
-    
-    const dataStr = JSON.stringify(data, null, 2)
-    const dataBlob = new Blob([dataStr], { type: 'application/json' })
-    
-    const url = URL.createObjectURL(dataBlob)
-    const link = document.createElement('a')
-    link.href = url
-    link.download = `momon-ga-carnival-data-${new Date().toISOString().split('T')[0]}.json`
-    document.body.appendChild(link)
-    link.click()
-    document.body.removeChild(link)
-    URL.revokeObjectURL(url)
-  }
 
   // データを圧縮してリンクを短縮
   const compressData = (data: any): string => {
@@ -86,34 +65,6 @@ const DataExport: React.FC = () => {
     }
   }
 
-  // データをインポート
-  const importData = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    if (!file) return
-
-    const reader = new FileReader()
-    reader.onload = (e) => {
-      try {
-        const data = JSON.parse(e.target?.result as string)
-        
-        if (data.favorites && data.tweets) {
-          // データをローカルストレージに保存
-          localStorage.setItem('favoriteUploads', JSON.stringify(data.favorites))
-          localStorage.setItem('tweets', JSON.stringify(data.tweets))
-          
-          alert('データをインポートしました！ページを再読み込みしてください。')
-          window.location.reload()
-        } else {
-          alert('無効なデータファイルです')
-        }
-      } catch (error) {
-        console.error('Failed to import data:', error)
-        alert('データのインポートに失敗しました')
-      }
-    }
-    reader.readAsText(file)
-    event.target.value = ''
-  }
 
   // データを展開
   const decompressData = (encodedData: string) => {
@@ -212,31 +163,6 @@ const DataExport: React.FC = () => {
         </div>
       </div>
 
-      {/* エクスポート機能 */}
-      <div className="comic-card" style={{ 
-        background: 'linear-gradient(135deg, rgba(76, 175, 80, 0.2), rgba(139, 195, 74, 0.1))', 
-        padding: '24px', 
-        borderColor: '#8bc34a', 
-        marginBottom: '24px' 
-      }}>
-        <h3 className="comic-text" style={{ color: '#fff3e0', marginBottom: '18px', fontSize: '1.5rem' }}>💾 データをエクスポート</h3>
-        <p className="comic-text" style={{ color: '#c8e6c9', marginBottom: '16px', fontSize: '1rem' }}>
-          現在のデータをJSONファイルとしてダウンロードできます
-        </p>
-        <button 
-          onClick={exportData}
-          className="comic-button"
-          style={{
-            padding: '12px 24px',
-            background: 'linear-gradient(45deg, #66bb6a, #4caf50)',
-            color: 'white',
-            fontSize: '1.1rem',
-            borderColor: '#2e7d32'
-          }}
-        >
-          📥 ダウンロード
-        </button>
-      </div>
 
       {/* 共有リンク生成 */}
       <div className="comic-card" style={{ 
@@ -265,10 +191,25 @@ const DataExport: React.FC = () => {
           {isGenerating ? '🔄 生成中...' : '🔗 共有リンク生成'}
         </button>
         
+        {copySuccess && (
+          <div style={{ 
+            marginTop: '16px',
+            padding: '12px',
+            background: 'linear-gradient(45deg, rgba(76, 175, 80, 0.8), rgba(139, 195, 74, 0.6))',
+            borderRadius: '8px',
+            textAlign: 'center',
+            animation: 'fadeIn 0.3s ease-in'
+          }}>
+            <p className="comic-text" style={{ color: '#fff', fontSize: '1.1rem', margin: 0 }}>
+              ✅ 共有リンクをクリップボードにコピーしました！
+            </p>
+          </div>
+        )}
+        
         {shareUrl && (
           <div style={{ marginTop: '16px' }}>
             <p className="comic-text" style={{ color: '#fff3e0', marginBottom: '8px', fontSize: '1rem' }}>
-              生成された共有リンク:
+              生成された共有リンク（自動でコピー済み）:
             </p>
             <div style={{ 
               background: 'rgba(0,0,0,0.3)', 
@@ -276,43 +217,18 @@ const DataExport: React.FC = () => {
               borderRadius: '8px', 
               wordBreak: 'break-all',
               fontSize: '0.9rem',
-              color: '#c8e6c9'
+              color: '#c8e6c9',
+              border: '1px solid rgba(76, 175, 80, 0.3)'
             }}>
               {shareUrl}
             </div>
+            <p className="comic-text" style={{ color: 'rgba(255,255,255,0.7)', fontSize: '0.9rem', marginTop: '8px' }}>
+              💡 このリンクを他の人に送ると、あなたの森の秘密基地が自動で共有されます
+            </p>
           </div>
         )}
       </div>
 
-      {/* データインポート */}
-      <div className="comic-card" style={{ 
-        background: 'linear-gradient(135deg, rgba(76, 175, 80, 0.2), rgba(139, 195, 74, 0.1))', 
-        padding: '24px', 
-        borderColor: '#8bc34a' 
-      }}>
-        <h3 className="comic-text" style={{ color: '#fff3e0', marginBottom: '18px', fontSize: '1.5rem' }}>📤 データをインポート</h3>
-        <p className="comic-text" style={{ color: '#c8e6c9', marginBottom: '16px', fontSize: '1rem' }}>
-          JSONファイルからデータを復元できます（現在のデータは上書きされます）
-        </p>
-        <input 
-          type="file" 
-          accept=".json"
-          onChange={importData}
-          className="comic-input"
-          style={{ 
-            width: '100%', 
-            padding: '12px', 
-            borderColor: 'rgba(255,255,255,0.4)',
-            background: 'rgba(255,255,255,0.05)',
-            color: 'white',
-            fontSize: '1.1rem',
-            marginBottom: '12px'
-          }} 
-        />
-        <p className="comic-text" style={{ color: 'rgba(255,255,255,0.7)', fontSize: '0.9rem' }}>
-          💡 共有リンクを開くだけで自動的にデータがインポートされます
-        </p>
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
Shorten share links, enable auto-copy, remove JSON import/export, and update Bullet Hell high scores to all-time TOP3.

Share links are now significantly shorter by compressing data and removing unnecessary fields, making them more practical for sharing. They are also automatically copied to the clipboard upon generation for convenience, with a visual success feedback instead of an alert. The JSON import/export functionality was removed to streamline the data sharing process, focusing solely on the improved share link feature. Bullet Hell high scores now track the top 3 all-time scores instead of daily scores, providing a more persistent and competitive leaderboard experience with medal indicators.

---
<a href="https://cursor.com/background-agent?bcId=bc-020bd8c6-89b1-42cb-8345-59d645593b22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-020bd8c6-89b1-42cb-8345-59d645593b22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

