### PR TITLE
Fix infinite reload loop on shared URL

### DIFF
--- a/apps/frontend/src/pages/DataExport.tsx
+++ b/apps/frontend/src/pages/DataExport.tsx
@@ -99,7 +99,11 @@ const DataExport: React.FC = () => {
       isCompressed = false
     }
     
-    if (importDataParam) {
+    // 既にインポート済みかチェック（セッションストレージを使用）
+    const importKey = `imported_${importDataParam}`
+    const alreadyImported = sessionStorage.getItem(importKey)
+    
+    if (importDataParam && !alreadyImported) {
       try {
         let data
         
@@ -115,8 +119,16 @@ const DataExport: React.FC = () => {
           localStorage.setItem('favoriteUploads', JSON.stringify(data.favorites))
           localStorage.setItem('tweets', JSON.stringify(data.tweets))
           
+          // インポート済みフラグを設定
+          sessionStorage.setItem(importKey, 'true')
+          
+          // URLパラメータをクリアしてから再読み込み
+          const url = new URL(window.location.href)
+          url.searchParams.delete('d')
+          url.searchParams.delete('import')
+          
           alert('共有されたデータをインポートしました！ページを再読み込みしてください。')
-          window.location.reload()
+          window.location.href = url.toString()
         }
       } catch (error) {
         console.error('Failed to import shared data:', error)


### PR DESCRIPTION
Fixes an infinite reload loop when opening shared URLs by clearing URL parameters and preventing duplicate imports.

The previous implementation caused an infinite loop because `window.location.reload()` was called after importing shared data, but the URL parameters remained, triggering the import process again on reload. This PR clears the relevant URL parameters and uses session storage to prevent re-importing the same data.

---
<a href="https://cursor.com/background-agent?bcId=bc-07f01a56-a1fd-4362-9407-df3fb83cc822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07f01a56-a1fd-4362-9407-df3fb83cc822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

