### PR TITLE
Fix settings general undefined name error

### DIFF
--- a/apps/frontend/src/pages/GeneralSettings.tsx
+++ b/apps/frontend/src/pages/GeneralSettings.tsx
@@ -113,7 +113,7 @@ const GeneralSettings: React.FC = () => {
         icon: '🔊'
       }
     }
-    return info[key]
+    return info[key] || { name: '不明な設定', description: '設定の説明がありません', icon: '❓' }
   }
 
   const clearAllData = () => {
@@ -186,7 +186,7 @@ const GeneralSettings: React.FC = () => {
               opacity: isPurchased ? 1 : 0.6
             }}>
               <div style={{ fontSize: 'clamp(2.5rem, 6vw, 3rem)', marginBottom: '12px' }}>
-                {info?.icon || '❓'}
+                {info.icon}
               </div>
               <div className="comic-text" style={{ 
                 fontSize: 'clamp(1.2rem, 4vw, 1.4rem)', 


### PR DESCRIPTION
Add a fallback object to `getSettingInfo` to prevent `undefined` access errors in General Settings.

The `getSettingInfo` function now guarantees that it always returns an object, even if the requested setting key does not exist. This prevents `TypeError: Cannot read properties of undefined (reading 'name')` when `info.name` or other properties are accessed in `GeneralSettings.tsx`, as `info` will always be a valid object. Consequently, optional chaining for `info.icon` was removed as it's no longer needed.

---
<a href="https://cursor.com/background-agent?bcId=bc-a35b64aa-36c5-4f2c-9928-657a2f37a3f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a35b64aa-36c5-4f2c-9928-657a2f37a3f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

