### PR TITLE
Create simple personal site layout

### DIFF
--- a/apps/frontend/public/index.html
+++ b/apps/frontend/public/index.html
@@ -3,65 +3,125 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>ほぼ日の朝</title>
+    <title>Yuri Natsume | Personal Site</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <div class="page-wrapper">
       <header class="page-header">
-        <div class="logo">ほぼ日の朝</div>
+        <div class="logo">Yuri Natsume</div>
         <nav class="main-nav">
-          <a href="#letters">きょうの手紙</a>
-          <a href="#note">日々のノート</a>
-          <a href="#market">ちいさな市</a>
-          <a href="revenue-lab/">収益分配ラボ</a>
+          <a href="#about">About</a>
+          <a href="#work">Work</a>
+          <a href="#notes">Notes</a>
+          <a href="#contact">Contact</a>
         </nav>
       </header>
 
       <main>
         <section class="hero">
-          <p class="date">2024年6月12日 水曜日</p>
-          <h1>お茶をわかすころ、風を感じましょう。</h1>
+          <p class="tag">designer &amp; writer in Tokyo</p>
+          <h1>静かなデザインと文章で、余白をつくる人。</h1>
           <p>
-            朝いちばんの空気を吸い込んで、机にすわって、ゆっくりと書きたくなる。そんな静かな時間を届けるための、ちいさなページです。
-            新しく「収益分配ラボ」を用意しました。書けば必ず報酬が発生するモデルを試せるシミュレーターに、ここから飛べます。
+            ことばを整え、シンプルなプロダクトを設計し、身のまわりの人が
+            少しだけ呼吸しやすくなるものをつくっています。ここでは、最近の
+            仕事やメモ、好きなものを短くまとめました。
           </p>
         </section>
 
-        <section class="card-grid">
-          <article id="letters">
-            <h2>きょうの手紙</h2>
+        <section id="about" class="panel">
+          <div class="panel-heading">
+            <h2>About</h2>
+            <p>ゆるやかなプロフィール</p>
+          </div>
+          <div class="panel-body">
             <p>
-              まっしろな便箋にひとこと「おはよう」を書くように、ここでは短い文章を更新していきます。季節の気配が、文字の向こうでゆれているとうれしいです。
+              プロダクトデザイナーとしてUI設計とコピーライティングを担当。
+              休日は写真散歩と茶道の稽古。余白のあるデザインと読みやすい文章が
+              好きで、個人では小さなWebサイトや冊子を作っています。
             </p>
-            <button>手紙を読む</button>
-          </article>
-          <article id="note">
-            <h2>日々のノート</h2>
-            <p>
-              手帳の余白に残るメモや落書きを、そのまま載せています。実験的だったり、ゆるかったり。読む人が自由に想像できるノートです。
-            </p>
-            <button>ノートを開く</button>
-          </article>
-          <article id="market">
-            <h2>ちいさな市</h2>
-            <p>
-              朝に似合う道具や食品を、月に数回だけ紹介します。売り切れたらまた次の出会いを待ちましょう。あわてず、ゆっくりと。
-            </p>
-            <button>市をのぞく</button>
-          </article>
-          <article id="revenue-lab">
-            <h2>収益分配ラボ</h2>
-            <p>
-              広告・スポンサー・投げ銭のプールを投稿者全員で山分けするモデルを、数値を変えながらその場で試算できます。オフラインでも動く静的ツールです。
-            </p>
-            <a class="button-link" href="revenue-lab/">シミュレーターを開く</a>
-          </article>
+            <ul>
+              <li>東京在住 / リモートワーク中心</li>
+              <li>興味: note執筆、ミニマルUI、紙とインクの質感</li>
+              <li>最近読んだ本: 「小さな声、光の粒」</li>
+            </ul>
+          </div>
+        </section>
+
+        <section id="work" class="panel">
+          <div class="panel-heading">
+            <h2>Selected Work</h2>
+            <p>手を動かしたもの</p>
+          </div>
+          <div class="cards">
+            <article class="card">
+              <h3>Quiet Journal</h3>
+              <p>
+                朝の1ページを書き溜めるためのWebノート。余白を広く取り、
+                サクッと書けるショートカットを実装。ロゴからUIコピーまで担当。
+              </p>
+              <span class="pill">UI/UX</span>
+            </article>
+            <article class="card">
+              <h3>Neighborhood Map</h3>
+              <p>
+                近所の喫茶店を歩いて集めたデータを公開した地図サイト。
+                写真撮影・文章・マップ設計・配色をシンプルにまとめています。
+              </p>
+              <span class="pill">Side project</span>
+            </article>
+            <article class="card">
+              <h3>Circle Newsletter</h3>
+              <p>
+                月1回のコミュニティニュースレター。編集・レイアウト・配信設定
+                まで一貫して担当し、開封率40%超を継続中です。
+              </p>
+              <span class="pill">Writing</span>
+            </article>
+          </div>
+        </section>
+
+        <section id="notes" class="panel">
+          <div class="panel-heading">
+            <h2>Notes</h2>
+            <p>最近のメモ</p>
+          </div>
+          <div class="note-list">
+            <div class="note">
+              <p class="note-date">2024-06-10</p>
+              <p>「情報の密度は高すぎないか」を見るだけで、画面がやわらぐ。</p>
+            </div>
+            <div class="note">
+              <p class="note-date">2024-06-02</p>
+              <p>香りのある朝、インクの色が濃くなる気がする。不思議。</p>
+            </div>
+            <div class="note">
+              <p class="note-date">2024-05-25</p>
+              <p>余白を消費しないアニメーション。速度より間合い。</p>
+            </div>
+          </div>
+        </section>
+
+        <section id="contact" class="panel contact-panel">
+          <div class="panel-heading">
+            <h2>Contact</h2>
+            <p>お仕事・感想はこちらへ</p>
+          </div>
+          <div class="contact-grid">
+            <div>
+              <p>Twitter / X: <a href="https://x.com" target="_blank">@yurinatsume</a></p>
+              <p>Mail: hello@yurinatsume.example</p>
+            </div>
+            <div>
+              <p>作った静的ツール: <a href="revenue-lab/">収益分配ラボ</a></p>
+              <p>配布中のテンプレートや冊子はご相談ください。</p>
+            </div>
+          </div>
         </section>
       </main>
 
       <footer>
-        <p>© 2024 ほぼ日の朝. すべてがゆっくり進んでいます。</p>
+        <p>© 2024 Yuri Natsume. Take a slow breath.</p>
       </footer>
     </div>
   </body>

--- a/apps/frontend/public/styles.css
+++ b/apps/frontend/public/styles.css
@@ -1,10 +1,11 @@
-@import url("https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@400;600&family=Noto+Sans+JP:wght@400;500&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@500;600&family=Inter:wght@400;500;600&display=swap");
 
 :root {
-  --paper: #fdf8ec;
-  --ink: #2b1a11;
-  --accent: #c26b3a;
-  --line: #d7c8aa;
+  --paper: #fcfaf6;
+  --ink: #1f1a1a;
+  --muted: #5e5854;
+  --line: #e4ded6;
+  --accent: #b5835a;
 }
 
 * {
@@ -13,12 +14,12 @@
 
 body {
   margin: 0;
-  font-family: "Noto Sans JP", system-ui, -apple-system, BlinkMacSystemFont,
+  font-family: "Inter", "Noto Sans JP", system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
-  background: radial-gradient(circle at top, #fff7e1 0%, #f2e4c8 60%, #e8d9bc);
+  background: radial-gradient(circle at 20% 20%, #f6efe6 0%, #f1e7dd 45%, #e9dfd5);
   color: var(--ink);
-  line-height: 1.75;
-  padding: 40px 24px 64px;
+  line-height: 1.7;
+  padding: 48px 20px 72px;
 }
 
 .page-wrapper {
@@ -26,117 +27,196 @@ body {
   margin: 0 auto;
   background: var(--paper);
   border: 1px solid var(--line);
-  padding: 32px 28px 40px;
-  box-shadow: 0 12px 24px rgb(0 0 0 / 0.08);
+  padding: 36px 32px 44px;
+  border-radius: 16px;
+  box-shadow: 0 18px 40px rgb(0 0 0 / 0.07);
 }
 
 .page-header {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding-bottom: 16px;
-  border-bottom: 2px solid var(--line);
+  padding-bottom: 18px;
+  border-bottom: 1px solid var(--line);
   margin-bottom: 32px;
 }
 
 .logo {
   font-family: "Noto Serif JP", serif;
-  font-size: 1.8rem;
-  letter-spacing: 0.2em;
+  font-size: 1.9rem;
+  letter-spacing: 0.08em;
 }
 
 .main-nav {
   display: flex;
-  gap: 16px;
+  gap: 14px;
   flex-wrap: wrap;
 }
 
 .main-nav a {
   text-decoration: none;
+  color: var(--muted);
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #f4eee7;
+  border: 1px solid #ede6dd;
+  font-size: 0.92rem;
+  transition: all 0.15s ease;
+}
+
+.main-nav a:hover {
   color: var(--ink);
-  border-bottom: 1px dotted var(--ink);
-  padding-bottom: 2px;
-  font-size: 0.95rem;
+  border-color: var(--ink);
+  background: #fefcf9;
 }
 
 .hero {
-  padding: 20px 0 32px;
+  padding: 12px 0 28px;
   border-bottom: 1px solid var(--line);
   margin-bottom: 32px;
 }
 
-.hero .date {
-  font-size: 0.85rem;
-  letter-spacing: 0.2em;
-  color: #6e513c;
+.hero .tag {
+  display: inline-block;
+  font-size: 0.9rem;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .hero h1 {
   font-family: "Noto Serif JP", serif;
-  font-size: clamp(1.8rem, 4vw, 2.6rem);
-  margin: 8px 0 12px;
+  font-size: clamp(1.9rem, 4vw, 2.8rem);
+  margin: 10px 0 12px;
 }
 
-.card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 16px;
+.hero p {
+  max-width: 720px;
+  color: #3a3432;
 }
 
-.card-grid article {
-  background: #fffdf6;
+.panel {
   border: 1px solid var(--line);
-  padding: 20px;
-  min-height: 220px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  box-shadow: 0 2px 6px rgb(0 0 0 / 0.05);
+  border-radius: 14px;
+  padding: 18px 18px 20px;
+  margin-bottom: 20px;
+  background: #fffdfb;
+  box-shadow: 0 4px 12px rgb(0 0 0 / 0.03);
 }
 
-.card-grid h2 {
+.panel-heading {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.panel h2 {
   font-family: "Noto Serif JP", serif;
   margin: 0;
   font-size: 1.3rem;
 }
 
-.card-grid button {
-  margin-top: auto;
-  align-self: flex-start;
-  border: 1px solid var(--ink);
-  background: transparent;
-  padding: 6px 16px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition: background 0.2s ease;
-}
-
-.card-grid button:hover {
-  background: var(--ink);
-  color: #fff;
-}
-
-.button-link {
-  display: inline-block;
-  margin-top: auto;
-  align-self: flex-start;
-  border: 1px solid var(--ink);
-  background: transparent;
-  padding: 7px 18px;
+.panel-heading p {
+  margin: 0;
+  color: var(--muted);
   font-size: 0.95rem;
-  color: var(--ink);
-  text-decoration: none;
-  transition: background 0.2s ease, color 0.2s ease;
 }
 
-.button-link:hover {
-  background: var(--ink);
-  color: #fff;
+.panel-body p {
+  margin-top: 0;
+  color: #332d2b;
+}
+
+.panel-body ul {
+  padding-left: 18px;
+  color: #3b3533;
+  margin: 12px 0 0;
+}
+
+.panel-body li + li {
+  margin-top: 6px;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.card {
+  padding: 14px 12px 16px;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.08rem;
+}
+
+.card p {
+  margin: 0;
+  color: #3a3532;
+}
+
+.pill {
+  align-self: flex-start;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #f5eee6;
+  border: 1px solid #e8ded3;
+  color: #6b6059;
+  font-size: 0.85rem;
+}
+
+.note-list {
+  display: grid;
+  gap: 10px;
+}
+
+.note {
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: #f9f4ed;
+  border: 1px dashed #e2d8cd;
+}
+
+.note-date {
+  margin: 0 0 4px;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  font-size: 0.9rem;
+}
+
+.note p {
+  margin: 0;
+  color: #2f2a28;
+}
+
+.contact-panel .contact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+a {
+  color: #2f5a83;
+}
+
+a:hover {
+  color: #1f3f5f;
 }
 
 footer {
-  border-top: 2px solid var(--line);
-  margin-top: 40px;
+  border-top: 1px solid var(--line);
+  margin-top: 34px;
   padding-top: 12px;
-  font-size: 0.85rem;
+  font-size: 0.88rem;
+  color: var(--muted);
+  text-align: center;
 }


### PR DESCRIPTION
## Summary
- rewrite the landing page content into a simple personal profile with about, work, notes, and contact sections
- refresh typography, spacing, and cards for the new personal site layout while keeping a link to the revenue lab tool

## Testing
- npm run build --prefix apps/frontend


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6944ebbe0d18832c94be4eb8aabbbc7e)