### PR TITLE
404ページを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ```
 apps/frontend/public/index.html        ← トップページ
 apps/frontend/public/works/*.html      ← 連作ごとの縦書きページ
+apps/frontend/public/404.html          ← 見つからないページ用
 apps/frontend/public/robots.txt        ← 検索エンジン向け
 apps/frontend/public/sitemap.xml       ← 検索エンジン向け
 apps/frontend/build.js                 ← public/ を dist/ にコピーするビルド
@@ -154,6 +155,19 @@ AWS Amplify で `amplify.yml` に従ってビルドし、`apps/frontend/dist` �
 
 `www` 付きで公開する場合など、URLが変わったときは手順5の3か所も直してください。
 ここが実際のURLと違うと、Xなどでリンクを貼ってもカード画像が表示されないことがあります。
+
+### 書き換えと転送（Rewrites and redirects）
+
+Amplify コンソールの **Hosting → Rewrites and redirects** に、次の2つを登録します。
+順番が大事で、www の転送を上に、404 を一番下に置きます。
+
+| # | Source | Target | Type |
+| --- | --- | --- | --- |
+| 1 | `https://www.momongacarnival.com/<*>` | `https://momongacarnival.com/<*>` | 301 |
+| 2 | `/<*>` | `/404.html` | 404 (Rewrite) |
+
+1がないと `www` ありとなしで同じサイトが二重に見えます。
+2がないと、存在しないURLがトップページを 200 で返してしまいます（ソフト404）。
 
 ## 過去のサイトについて
 

--- a/apps/frontend/public/404.html
+++ b/apps/frontend/public/404.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ページが見つかりません｜齊藤智都</title>
+  <meta name="robots" content="noindex" />
+
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+  <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+  <meta name="theme-color" content="#fbfbfa" />
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&family=Zen+Maru+Gothic:wght@400;500;700&display=swap" rel="stylesheet" />
+
+  <style>
+    :root {
+      --font: "Poppins", "Zen Maru Gothic", "Hiragino Maru Gothic ProN", "Yu Gothic",
+        "Noto Sans JP", system-ui, sans-serif;
+
+      color-scheme: light dark;
+      --paper: #fbfbfa;
+      --ink: #14140f;
+      --ink-soft: #4a4a44;
+      --ink-faint: #8a8a82;
+      --rule: rgba(20, 20, 15, 0.14);
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --paper: #111110;
+        --ink: #eeeee8;
+        --ink-soft: #b4b4ac;
+        --ink-faint: #83837b;
+        --rule: rgba(238, 238, 232, 0.18);
+      }
+    }
+
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      min-height: 100dvh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 48px 24px;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: var(--font);
+      font-size: 16px;
+      line-height: 1.95;
+      letter-spacing: 0.04em;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    .inner { max-width: 34rem; margin: 0 auto; width: 100%; }
+
+    /* 円相は画面の外へはみ出すので、この枠で切り取ります */
+    .deco {
+      position: fixed;
+      inset: 0;
+      overflow: hidden;
+      pointer-events: none;
+    }
+
+    .deco svg {
+      position: absolute;
+      top: 12%;
+      right: -60px;
+      width: 260px;
+      height: 260px;
+      opacity: 0.09;
+      color: var(--ink);
+    }
+
+    @media (max-width: 640px) {
+      .deco svg { width: 180px; height: 180px; right: -46px; }
+    }
+
+    .code {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.3em;
+      color: var(--ink-faint);
+      margin: 0 0 6px;
+    }
+
+    h1 {
+      font-size: clamp(22px, 5vw, 28px);
+      font-weight: 700;
+      letter-spacing: 0.1em;
+      margin: 0 0 24px;
+    }
+
+    p { margin: 0 0 1.4em; color: var(--ink-soft); }
+
+    a.home {
+      display: inline-block;
+      font-size: 14px;
+      letter-spacing: 0.12em;
+      color: inherit;
+      text-decoration: none;
+      border-bottom: 1px solid var(--rule);
+      padding-bottom: 2px;
+      transition: border-color 0.2s ease;
+    }
+
+    a.home:hover,
+    a.home:focus-visible { border-bottom-color: var(--ink); }
+  </style>
+</head>
+<body>
+  <div class="deco" aria-hidden="true">
+    <svg viewBox="0 0 200 200">
+      <path d="M150 42a78 78 0 1 0 22 47" fill="none" stroke="currentColor" stroke-width="9" stroke-linecap="round" />
+    </svg>
+  </div>
+
+  <div class="inner">
+    <p class="code">404</p>
+    <h1>ページが見つかりません</h1>
+    <p>お探しのページは、移動したか、なくなったようです。<br />アドレスの打ち間違いかもしれません。</p>
+    <a class="home" href="/">齊藤智都のホームページへ</a>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
存在しないアドレスに来た人のためのページを、サイトと同じ意匠で用意しました。

- `apps/frontend/public/404.html` を追加（404の表示、事情の説明、ホームページへの導線）
- 検索エンジンには載せない指定（`noindex`）
- 円相は固定枠で切り取っているため、どの画面幅でもスクロールは発生しません
- README に、Amplify 側で必要な2つの設定を記録

## マージ後に必要な設定

このページはファイルを置くだけでは使われません。Amplify コンソールの
**Hosting → Rewrites and redirects** に次の2つを登録してください。順番が大事で、
www の転送を上に、404 を一番下に置きます。

| # | Source | Target | Type |
| --- | --- | --- | --- |
| 1 | `https://www.momongacarnival.com/<*>` | `https://momongacarnival.com/<*>` | 301 |
| 2 | `/<*>` | `/404.html` | 404 (Rewrite) |

現状は、存在しないURLがトップページを 200 で返しており（ソフト404）、
`www` ありでも同じサイトが表示される状態です。上の2つで両方が解消します。

## 確認

1000 / 390 / 320px の3サイズを明暗どちらの配色でも確認し、縦横のスクロールが
発生しないこと、ホームへのリンクが正しいこと、JSエラーがないことを確かめました。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyRVdmiizq25jDgckk7dF7)_